### PR TITLE
Update setup.py for transitive install of numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,20 @@
-from numpy.distutils.core import Extension
+from setuptools import dist
+dist.Distribution().fetch_build_eggs(['numpy>=1.17.0,<2'])
 
 long_description = """
 A numpy binding for the Poisson E-Test, described in this paper:
-
 http://www.ucs.louisiana.edu/~kxk4695/JSPI-04.pdf
-
 I basically just minimally edited the original fortran code so that numpy f2py
 could pick it up. The original code can be found in an early commit to this repo
 or via this link:
-
 http://www.ucs.louisiana.edu/~kxk4695/statcalc/pois2pval.for
 """
 
-fortran_ext = Extension(
-    "poisson_etest.poisson_etest_fortran", sources=["lib/poisson_etest.f"]
-)
-
 if __name__ == "__main__":
-    from numpy.distutils.core import setup
+    from numpy.distutils.core import setup, Extension
+    fortran_ext = Extension(
+        "poisson_etest.poisson_etest_fortran", sources=["lib/poisson_etest.f"]
+    )
 
     setup(
         name="poisson_etest",
@@ -31,4 +28,6 @@ if __name__ == "__main__":
         long_description=long_description,
         ext_modules=[fortran_ext],
         package_dir={"poisson_etest": "lib"},
+        setup_requires=["numpy>=1.17.0,<2"],
+        install_requires=["numpy>=1.17.0,<2"]
     )


### PR DESCRIPTION
**Problem**
- Found issues when using this package in that numpy had to be installed for it to work
    - On builds, we had to manually specify that numpy was installed first as opposed to just including it in a list of requirements

**Solution**
- Add in numpy build egg to allow numpy to be used in setup.py
- Declare numpy as a `setup_requires` and `install_requires` package to allow transitive installation if numpy not already installed

**Thanks**
- Seperately, thanks for a great repo, found it very useful!